### PR TITLE
chore(webpage-impact): set viewport size to reasonable default

### DIFF
--- a/src/lib/webpage-impact/index.ts
+++ b/src/lib/webpage-impact/index.ts
@@ -171,6 +171,9 @@ const WebpageImpactUtils = () => {
               config.emulateNetworkConditions as keyof typeof PredefinedNetworkConditions
             ]
           );
+        } else {
+          // set viewport to a reasonable size for laptops. I hope that is a sensible default.
+          await page.setViewport({width: 1440, height: 900});
         }
 
         await page.setRequestInterception(true);


### PR DESCRIPTION
puppeteers default is 800x600, which loads the page differently than for a typical page load on a laptop.