### PR TITLE
chore: downgrade ubuntu runner to 22.04

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04 # setting to 22.04 due to AppArmor restrictions that block Chromium on 24.04
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
ubuntu-latest is currently on 24.04. Due to tightend AppArmor restrictions under this version, Chromium is blocked an a test fails. Downgrading, as a simple workaround for now, to 22.04.