### PR TITLE
Rename co2.js output

### DIFF
--- a/src/lib/co2js/index.ts
+++ b/src/lib/co2js/index.ts
@@ -41,7 +41,7 @@ export const Co2js = PluginFactory({
       return result
         ? {
             ...input,
-            'carbon-operational': roundToDecimalPlaces(result, 3),
+            'estimated-carbon': roundToDecimalPlaces(result, 3),
           }
         : input;
     });


### PR DESCRIPTION
Per #105, this PR renames the output of the CO2.js plugin to `estimated-carbon` to avoid any confusion.