### PR TITLE
fix: update missed carbon-operational string to estimated-carbon

### DIFF
--- a/src/lib/co2js/README.md
+++ b/src/lib/co2js/README.md
@@ -144,7 +144,7 @@ tree:
               device: 560.98
               dataCenter:
                 country: TWN
-          carbon-operational: 0.119
+          estimated-carbon: 0.119
 ```
 
 ## TypeScript


### PR DESCRIPTION
Not sure how that was lost... but need to fix it.