### PR TITLE
chore: bump minimum release age in renovate config to 3 days

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,23 +7,30 @@
     ":automergeLinters",
     ":automergeTesters"
   ],
-  "addLabels": ["dependencies"],
+  "addLabels": [
+    "dependencies"
+  ],
   "automergeType": "branch",
   "prConcurrentLimit": 5,
   "prCreation": "not-pending",
   "rangeStrategy": "bump",
-  "minimumReleaseAge": "1 day",
+  "minimumReleaseAge": "3 day",
   "nvm": {
     "enabled": false
   },
   "packageRules": [
     {
-      "updateTypes": ["minor", "patch"],
+      "updateTypes": [
+        "minor",
+        "patch"
+      ],
       "automerge": true
     },
     {
       "description": "Ignore engines field in package.json",
-      "matchDepTypes": ["engines"],
+      "matchDepTypes": [
+        "engines"
+      ],
       "enabled": false
     }
   ]


### PR DESCRIPTION
see title