### PR TITLE
chore: update release workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,13 +16,13 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         with:
           version: 10.34.3
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           cache: 'pnpm'
           node-version: 24.16.0

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,18 +1,19 @@
+# SPDX-FileCopyrightText: 2024 Alexander zur Bonsen <alexander.zur.bonsen@tngtech.com>
+# SPDX-License-Identifier: Apache-2.0
+
 name: Release Impact Framework Webpage Plugins
 
+# Triggered by the version tag pushed by scripts/prepare-release.sh.
+# A single run tests, builds, publishes to npm (via OIDC) and creates the
+# GitHub release. The `npm-publish` environment provides the manual approval gate.
 on:
-  workflow_dispatch:
-    inputs:
-      ref:
-        description: "The tag to release (leave empty to use latest tag)"
-        required: false
-        type: string
-  release:
-    types: [published]
+  push:
+    tags:
+      - 'v*'
 
 permissions:
-  id-token: write
-  contents: read
+  id-token: write # OIDC authentication for npm publish
+  contents: write # create the GitHub release
 
 jobs:
   release:
@@ -20,47 +21,13 @@ jobs:
     environment: npm-publish
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-
-      - name: Determine Release Tag
-        id: get_tag
-        env:
-          RELEASE_REF: ${{ github.event_name == 'release' && github.event.release.tag_name || github.event.inputs.ref }}
-        run: |
-          if [ -n "$RELEASE_REF" ]; then
-            if git show-ref --tags --verify --quiet "refs/tags/$RELEASE_REF"; then
-              TAG="$RELEASE_REF"
-            elif git show-ref --tags --verify --quiet "refs/tags/v$RELEASE_REF"; then
-              TAG="v$RELEASE_REF"
-            else
-              echo "Release tag does not exist: $RELEASE_REF"
-              exit 1
-            fi
-          else
-            # Get the latest tag
-            TAG=$(git tag --sort=-version:refname | head -1)
-          fi
-
-          if [ -z "$TAG" ]; then
-            echo "No release tag found"
-            exit 1
-          fi
-
-          echo "Releasing tag: $TAG"
-          printf 'tag=%s\n' "$TAG" >> "$GITHUB_OUTPUT"
-
-      - name: Checkout Release Tag
-        env:
-          RELEASE_TAG: ${{ steps.get_tag.outputs.tag }}
-        run: git switch --detach "$RELEASE_TAG"
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Install pnpm
         run: npm install -g pnpm
 
       - name: Setup Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24.16.0
           cache: 'pnpm'
@@ -75,12 +42,24 @@ jobs:
       - name: Install Dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Verify tag matches package.json version
+        run: |
+          PKG_VERSION="v$(node -p "require('./package.json').version")"
+          if [ "$PKG_VERSION" != "$GITHUB_REF_NAME" ]; then
+            echo "Tag $GITHUB_REF_NAME does not match package.json version $PKG_VERSION"
+            exit 1
+          fi
+
       - name: Test
-        run: pnpm run test
+        run: pnpm run test:ci
 
       - name: Build
         run: pnpm run build
 
       - name: Publish to NPM
-        run: |
-          npm publish --access public
+        run: npm publish --access public
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release create "$GITHUB_REF_NAME" --generate-notes --verify-tag

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,13 +16,13 @@ jobs:
   test:
     runs-on: ubuntu-22.04 # setting to 22.04 due to AppArmor restrictions that block Chromium on 24.04
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         with:
           version: 10.34.3
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           cache: 'pnpm'
           node-version: 24.16.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,3 +81,12 @@ Please see [conventionalcommits.org][conventionalcommits] to learn how to format
 For changes to the documentation / website you can use the type "docs" directly.
 
 [conventionalcommits]: https://www.conventionalcommits.org
+
+### A note on branch protection
+
+`main` is protected by a repository ruleset (not classic branch protection) that requires a pull request with 1 approval, passing `test`/`lint`/`DCO` checks, signed commits, and blocks force-pushes and deletion. The bypass list keeps this from being looser than necessary:
+
+- Repository Admin role: bypass `always` — needed so the release author can push the version bump commit directly to `main` in step 1.
+- Renovate app: bypass `pull_request` — lets Renovate auto-merge its dependency PRs without a human approval (it still waits for its own checks).
+
+Everyone else must go through a reviewed, checked PR.

--- a/DISTRIBUTION.md
+++ b/DISTRIBUTION.md
@@ -1,17 +1,10 @@
 # Distribution
 
-To create a new release
+To create a new release:
 
-1. Run `./scripts/prepare-release.sh` to create a version bump commit and a tag.
-2. Create the GitHub release.
-3. The release workflow should be triggered automatically and an admin needs to approve it. It picks up the latest tag to create a release.
+1. Run `./scripts/prepare-release.sh x.y.z` to create the version bump commit and tag, and push both to `main`.
+2. The release workflow (`.github/workflows/release.yaml`) triggers automatically on the pushed `v*` tag. An admin approves the `npm-publish` environment, after which a single run tests, builds, publishes to npm (via OIDC), and creates the GitHub release.
 
 Background:
 
-Security restrictions in the separation of code and release repo make it hard to have one automated workflow for the release that does all the things at once (create version bump commit and tag, publish release).
-
-To make the two step setup convenient the branch protection rules are configured such that pushes are possible without requiring all checks to pass.
-
-This is a short-coming since it can lead to a broken main branch.
-But otherwise I have to do even more manual stuff. Doesn't make me happy...
-Might have to reconsider if this proves to be the wrong choice.
+Publishing uses npm trusted publishing (OIDC), so no long-lived npm token is stored. Everything now happens in one workflow, triggered by the tag — there is no longer a separate release repo or a manual "create GitHub release" step.

--- a/renovate.json
+++ b/renovate.json
@@ -2,6 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended",
+    "helpers:pinGitHubActionDigests",
     ":dependencyDashboard",
     ":automergeTypes",
     ":automergeLinters",

--- a/scripts/prepare-release.sh
+++ b/scripts/prepare-release.sh
@@ -38,7 +38,7 @@ fi
 
 # Bump the version (updates package.json)
 echo "Bumping version..."
-pnpm version $VERSION_ARG -m "chore: release version %s" --sign-git-tag
+pnpm version $VERSION_ARG -m "chore: bump version to %s" --sign-git-tag
 
 echo "Pushing change and tag..."
 git push --follow-tags


### PR DESCRIPTION
Make the release workflow more convenient by
triggering it by pushing a version tag (and bump
commit). This is done by an admin (doing it in
the release workflow would require looser branch
protection rules or a bypass identity).

The release workflow is triggered on the push of
the tag. Needs to be approved by an admin before
it can publish.

Also pin gh actions in all workflows and update
docs.